### PR TITLE
update stashcp timeout limit

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -234,7 +234,7 @@ file=""
 loc="."
 source=""
 recursive=0
-seconds=15
+seconds=60
 diff=$((seconds * 10)) ## 10Bps
 
 ## Process arguments


### PR DESCRIPTION
Requested change: line 237; set seconds variable to 60 instead of 15. Stashcp tests are showing a high rate (~20% of total jobs) of timeouts using 15 seconds, and we would like to change it to 60 seconds so a higher percentage of jobs are seen by servers.