### PR TITLE
Timeout and stashcp curl change

### DIFF
--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -25,6 +25,9 @@ start_watchdog(){
 			newSize=$(du -b $file | cut -f1)
 			nextSize=$((prevSize+diff))
 			wantSize=$((nextSize<expSize?nextSize:expSize))
+			if [ $newSize -eq $expSize ]; then
+				exit 0
+			fi
 			if [ $newSize -lt $((wantSize)) ]; then #if time out
 				echo "killing process after timeout of $timeout seconds"
 				kill -0 $$

--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -26,7 +26,9 @@ start_watchdog(){
 			nextSize=$((prevSize+diff))
 			wantSize=$((nextSize<expSize?nextSize:expSize))
 			if [ $newSize -lt $((wantSize)) ]; then #if time out
-				kill -0 $$ || exit 0
+				echo "killing process after timeout of $timeout seconds"
+				kill -0 $$
+				exit 20
 			else #if file increases accordingly
 				prevSize=$(du -b $file | cut -f1)
 			fi
@@ -36,8 +38,7 @@ start_watchdog(){
 		fi
 	done
 	
-	echo "killing process after timeout of $timeout seconds"
-	kill $$
+	
 }
 
 

--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -14,25 +14,25 @@ start_watchdog(){
 	file="$2"
 	diff="$3"
 	expSize="$4"
-	(( i = timeout ))
 	prevSize=0
-	while (( i > 0 ))
+	newSize=0
+	while (( newSize<expSize ))
 	do
 		if [ -e $file ]; then
+			sleep $timeout #check status after every x seconds
+			sync #need to write to disc for du to work
+			sleep 1 #allow disk to finish writing (technically adds 1 second to next iteration's check)
 			newSize=$(du -b $file | cut -f1)
 			nextSize=$((prevSize+diff))
 			wantSize=$((nextSize<expSize?nextSize:expSize))
-			if [ $newSize -lt $((wantSize)) ]; then
+			if [ $newSize -lt $((wantSize)) ]; then #if time out
 				kill -0 $$ || exit 0
-				sleep 1
-				(( i -= 1 ))
-			else
+			else #if file increases accordingly
 				prevSize=$(du -b $file | cut -f1)
-				(( i = timeout ))
 			fi
-		else
-			sleep 1
-			(( i -= 1 )) ## to avoid infinite loop
+		else 
+			echo "file does not exist"
+			newSize=expSize ## to avoid infinite loop
 		fi
 	done
 	

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -123,10 +123,9 @@ function doStashCpSingle {
 			## send info out to flume
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
-			header="[{ \"headers\" : {\"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\" },"
-			body="\"body\" : \"$((st2/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
-			echo $header$body > data.json
-			timeout 10 curl -X POST -H 'Content-Type: application/json; charset=UTF-8' http://hadoop-dev.mwt2.org:80/ -d @data.json > /dev/null 2>&1 
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\", \"start_time\": \"$((st1/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
+			echo $payload > data.json
+			timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp/rec/ -d @data.json > /dev/null 2>&1 
 			rm data.json 2>&1
 		else 	
 			## second attempt to pull from local cache failed, pulling from trunk
@@ -153,10 +152,9 @@ function doStashCpSingle {
 				failovertimes=("${failovertimes[@]}" $st2) # time that the failed pull started
 				## send info out to flume
 				timestamp=$(date +%s)
-				header="[{ \"headers\" : {\"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\" },"
-				body="\"body\" : \"$((st3/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
-				echo $header$body > data.json
-				timeout 10 curl -X POST -H 'Content-Type: application/json; charset=UTF-8' http://hadoop-dev.mwt2.org:80/ -d @data.json > /dev/null 2>&1
+				payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\", \"start_time\": \"$((st1/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
+				echo $payload > data.json
+				timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp/rec/ -d @data.json > /dev/null 2>&1 
 				rm data.json 2>&1
 			else
 				failfiles=("${failfiles[@]}" $downloadFile)

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -103,10 +103,9 @@ function doStashCpSingle {
 		## send info out to flume
 		hn=$sourcePrefix
 		timestamp=$(date +%s)
-		header="[{ \"headers\" : {\"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\" },"
-		body="\"body\" : \"$((st1/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
-		echo $header$body > data.json
-		timeout 10 curl -X POST -H 'Content-Type: application/json; charset=UTF-8' http://hadoop-dev.mwt2.org:80/ -d @data.json > /dev/null 2>&1 
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\", \"start_time\": \"$((st1/1000)),$downloadFile,$mySz,$dltm,$OSG_SITE_NAME,$hn\"}]"
+		echo $payload > data.json
+		timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp/rec/ -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
 	else
 		## pull from local cache failed; try again


### PR DESCRIPTION
Ilija and I think that the du command in downloading_timeout.sh is never reading any disk usage because unix wouldn't see any disk usage during a file transfer without the use of sync before the du command. We have proposed this, along with minor changes to the loop to check every $timeout seconds as opposed to every 1 second, and moving the kill command to inside the timeout condition, rather than at the end of the loop 
(echo "killing process after timeout of $timeout seconds"
-	kill $$)

In stashcp, we updated the curl command to point to the current host, as I understand we are not using the hadoop cluster for this purpose at the moment. Let me know what you think and thanks.

Tony