### PR TITLE
index update and space check

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -88,6 +88,14 @@ function doStashCpSingle {
 	month=$(date +%m)
 
 	## First attempt
+	## Check destination directory for space
+	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
+	if [ $dirSpace -lt $mySz ]; then
+		noSpace=true
+		echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."
+		exit 1
+	fi
+	
 	st1=$(date +%s%3N)
 	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 	res=$?
@@ -101,9 +109,10 @@ function doStashCpSingle {
 		## send info out to flume
 		hn=$sourcePrefix
 		timestamp=$(date +%s)
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\"}"
+		xrdcpVersion="$(xrdcp -V 2>&1)"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
-		timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp-$month/rec/ -d @data.json > /dev/null 2>&1 
+		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
 	else
 		## pull from local cache failed; try again
@@ -121,9 +130,9 @@ function doStashCpSingle {
 			## send info out to flume
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
-			timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp-$month/rec/ -d @data.json > /dev/null 2>&1
+			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
 		else 	
 			## second attempt to pull from local cache failed, pulling from trunk
@@ -150,9 +159,9 @@ function doStashCpSingle {
 				failovertimes=("${failovertimes[@]}" $st2) # time that the failed pull started
 				## send info out to flume
 				timestamp=$(date +%s)
-				payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\"}"
+				payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 				echo $payload > data.json
-				timeout 10 curl -XPOST http://uct2-es-door.mwt2.org:9200/stashcp-$month/rec/ -d @data.json > /dev/null 2>&1
+				timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 				rm data.json 2>&1
 			else
 				failfiles=("${failfiles[@]}" $downloadFile)

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -90,6 +90,7 @@ function doStashCpSingle {
 	## First attempt
 	## Check destination directory for space
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
+	noSpace=false
 	if [ $dirSpace -lt $mySz ]; then
 		noSpace=true
 		echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."


### PR DESCRIPTION
Added a space check for the destination directory and also saved it as a variable to be sent to the ES index. We need to curl to uct2-int.mwt2.org:9951 now which is handled by a Python script we've tested to re-direct job data to the usual ES host. In Kibana it can be found in "stashcp-*". Before, uct2-es-door.mwt2.org was not accepting curls from stashcp.