### PR TITLE
Updates to fix bugs

### DIFF
--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -45,7 +45,7 @@ wait $xrdpid
 xrd_exit=$?
 
 # If xrdcp command exits, kill the watchdog and exit using xrdcp's exit code
-kill $watchdog_pid
+kill $watchdog_pid 2>/dev/null
 exit $xrd_exit
 
 ## Based on: http://fahdshariff.blogspot.com/2013/08/executing-shell-command-with-timeout.html

--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -1,57 +1,73 @@
-#!/bin/bash
 while getopts "t:f:d:s:" opt; do
   case "$opt" in
       t) timeout=$OPTARG ;;
-	  f) file=$OPTARG ;;
-	  d) diff=$OPTARG ;;
-	  s) expSize=$OPTARG ;;
+      f) file=$OPTARG ;;
+      d) diff=$OPTARG ;;
+      s) expSize=$OPTARG ;;
   esac
 done
 shift $((OPTIND-1))
 
-start_watchdog(){
-	timeout="$1"
-	file="$2"
-	diff="$3"
-	expSize="$4"
-	(( i = timeout ))
-	prevSize=0
-	while (( i > 0 ))
-	do
-		if [ -e $file ]; then
-			newSize=$(du -b $file | cut -f1)
-			nextSize=$((prevSize+diff))
-			wantSize=$((nextSize<expSize?nextSize:expSize))
-			if [ $newSize -lt $((wantSize)) ]; then
-				# kill -0 $$ || exit 0
-				sleep 1
-				(( i -= 1 ))
-			elif [ $newSize -eq $expSize ]; then
-				# Finished file
-				exit 0
-			else
-				prevSize=$(du -b $file | cut -f1)
-				(( i = timeout ))
-				sleep 1
-			fi
-		else
-			sleep 1
-			(( i -= 1 )) ## to avoid infinite loop
-		fi
-	done
-	
-	echo "killing process after timeout of $timeout seconds"
-	kill $$
-}
 
+start_watchdog(){
+    timeout="$1"
+    file="$2"
+    diff="$3"
+    expSize="$4"
+    prevSize=0
+    newSize=0
+    SERVICE='xrdcp'
+    while (( newSize<expSize ))
+    do 
+        sleep $timeout #check status after every x seconds
+        if [ -e $file ]; then
+            newSize=$(du -b $file | cut -f1)
+            nextSize=$((prevSize+diff))
+            wantSize=$((nextSize<expSize?nextSize:expSize))
+            if [ $newSize -eq $expSize ]; then
+                #finished
+                exit 0
+            fi
+            if [ $newSize -lt $wantSize ]; then #if time out
+                echo "killing process after timeout of $timeout seconds"
+                if ps ax | grep -v grep | grep $SERVICE > /dev/null
+                then
+                    #xrdcp running, kill xrdcp now
+                    pgrep xrdcp | xargs kill -9
+                    exit 1
+                else
+                    #xrdcp already aborted on its own, use xrdcp exit code
+                    xrdcp_abort=$?
+                    exit $xrdcp_abort
+                fi
+                
+            else #if file increases accordingly
+                prevSize=$(du -b $file | cut -f1)
+            fi
+        else
+            #file does not exist (timeout)
+            echo "download did not start - killing process after timeout of $timeout seconds"
+            if ps ax | grep -v grep | grep $SERVICE > /dev/null
+            then
+                #xrdcp running, killing now
+                pgrep xrdcp | xargs kill -9
+                exit 1
+            else
+               #xrdcp not running, use xrdcp exit code
+                xrdcp_abort=$?
+                exit $xrdcp_abort
+            fi
+        
+        fi
+    done
+    
+    
+}
 
 start_watchdog "$timeout" "$file" "$diff" "$expSize" &
 watchdog_pid=$!
 "$@"
 cp_exit=$?
 
-# If the cp command exits, kill the watchdog
 kill $watchdog_pid
 exit $cp_exit
-
-## Based on: http://fahdshariff.blogspot.com/2013/08/executing-shell-command-with-timeout.html

--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -1,23 +1,21 @@
-while getopts "t:f:d:s:p:" opt; do
+while getopts "t:f:d:s:" opt; do
   case "$opt" in
       t) timeout=$OPTARG ;;
       f) file=$OPTARG ;;
       d) diff=$OPTARG ;;
       s) expSize=$OPTARG ;;
-      p) xpid=$OPTARG ;;
   esac
 done
 shift $((OPTIND-1))
 
 
 start_watchdog(){
-    timeout="$1"
-    file="$2"
-    diff="$3"
-    expSize="$4"
-    xpid="$5"
+    timeout=$1
+    file=$2
+    diff=$3
+    expSize=$4
+    xrdpid=$5
     prevSize=0
-    newSize=0
     while (( newSize<expSize ))
     do 
         sleep $timeout #check status after every x seconds
@@ -25,46 +23,29 @@ start_watchdog(){
             newSize=$(du -b $file | cut -f1)
             nextSize=$((prevSize+diff))
             wantSize=$((nextSize<expSize?nextSize:expSize))
-            if [ $newSize -eq $expSize ]; then
-                #finished
-                exit 0
-            fi
             if [ $newSize -lt $wantSize ]; then #if time out
-                echo "killing process after timeout of $timeout seconds"
-                if ps -p $xpid > /dev/null
-                then
-                    #xrdcp running, kill xrdcp now
-                    kill -9 $xpid
-                else
-                    #xrdcp already aborted on its own, use xrdcp exit code
-                    xrdcp_abort=$?
-                    exit $xrdcp_abort
-                fi
-                
+                kill -9 $xrdpid
             else #if file increases accordingly
                 prevSize=$(du -b $file | cut -f1)
             fi
         else
-            #file does not exist (timeout)
-            if ps -p $xpid > /dev/null
-            then
-                #xrdcp running, killing now
-                kill -9 $xpid
-            else
-               #xrdcp not running, use xrdcp exit code
-                xrdcp_abort=$?
-                exit $xrdcp_abort
-            fi
+            kill -9 $xrdpid
         fi
-    done
-    
-    
+    done   
 }
 
-start_watchdog "$timeout" "$file" "$diff" "$expSize" "$xpid" &
+#Execute xrdcp
+"$@" &
+xrdpid=$!
+
+start_watchdog "$timeout" "$file" "$diff" "$expSize" "$xrdpid" &
 watchdog_pid=$!
-"$@"
-cp_exit=$?
-# If the cp command exits, kill the watchdog
+
+wait $xrdpid
+xrd_exit=$?
+
+# If xrdcp command exits, kill the watchdog and exit using xrdcp's exit code
 kill $watchdog_pid
-exit $cp_exit
+exit $xrd_exit
+
+## Based on: http://fahdshariff.blogspot.com/2013/08/executing-shell-command-with-timeout.html

--- a/bin/downloading_timeout.sh
+++ b/bin/downloading_timeout.sh
@@ -61,7 +61,7 @@ start_watchdog(){
     
 }
 
-start_watchdog "$timeout" "$file" "$diff" "$expSize" &
+start_watchdog "$timeout" "$file" "$diff" "$expSize" "$xpid" &
 watchdog_pid=$!
 "$@"
 cp_exit=$?

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -86,23 +86,38 @@ function doStashCpSingle {
 	mb=$((mySz/1000000))
 	tm=$((300+mb)) ## 5 minutes + 1MBps
 	month=$(date +%m)
+	xrdcpVersion="$(xrdcp -V 2>&1)"
 
 	## First attempt
 	## Check destination directory for space
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
 	noSpace=false
+	##if not enough space, curl jobStatus and exit
 	if [ $dirSpace -lt $mySz ]; then
-		noSpace=true
+		jobStatus="Not enough space"
 		echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."
+		
+		dSz=0
+		timestamp=$(date +%s)
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		echo $payload > data.json
+		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
+		rm data.json 2>&1
 		exit 1
 	fi
 	
 	st1=$(date +%s%3N)
 	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	res=$?
 	dl1=$(date +%s%3N)
 	if [ $res -eq 0 ]; then
 		## pull from local cache succeeded
+		if [ $dSz -eq $mySz ]; then
+			jobStatus="Success"
+		else
+			jobStatus="No timeout but filesize does not match downloaded size"
+		fi
 		dltm=$((dl1-st1))
 		if [ $3 ]; then 	## update info only if I want to
 			updateInfo $st1 $downloadFile $mySz $dltm
@@ -111,7 +126,7 @@ function doStashCpSingle {
 		hn=$sourcePrefix
 		timestamp=$(date +%s)
 		xrdcpVersion="$(xrdcp -V 2>&1)"
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -120,10 +135,16 @@ function doStashCpSingle {
 		## Second attempt
 		st2=$(date +%s%3N)
 		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		res=$?
 		dl2=$(date +%s%3N)
 		if [ $res -eq 0 ]; then 	
 			## second attempt to pull from local cache succeeded
+			if [ $dSz -eq $mySz ]; then
+				jobStatus="Success"
+			else
+				jobStatus="No timeout but filesize does not match downloaded size"
+			fi
 			dltm=$((dl2-st2))
 			if [ $2 ]; then 	## update info only if I want to
 				updateInfo $st2 $downloadFile $mySz $dltm
@@ -131,13 +152,13 @@ function doStashCpSingle {
 			## send info out to flume
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
 		else 	
 			## second attempt to pull from local cache failed, pulling from trunk
-		    if [ $debug -eq 2 ]; then	
+		    	if [ $debug -eq 2 ]; then	
 				## print out debug info
 				echo "Pull of $downloadFile from $sourcePrefix failed."
 				echo "Command: xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 2>&1"
@@ -148,23 +169,31 @@ function doStashCpSingle {
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
 			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
+			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			res=$?
 			dl3=$(date +%s%3N)
+			dltm=$((dl3-st3))
 			if [ $res -eq 0 ]; then
 				## pull from trunk succeeded
-				dltm=$((dl3-st3))
+				if [ $dSz -eq $mySz ]; then
+					jobStatus="Success"
+				else
+					jobStatus="No timeout but filesize does not match downloaded size"
+				fi
+				#dltm=$((dl3-st3))
 				if [ $2 ]; then
 					updateInfo $st3 $downloadFile $mySz $dltm
 				fi
 				failoverfiles=("${failoverfiles[@]}" $downloadFile)
 				failovertimes=("${failovertimes[@]}" $st2) # time that the failed pull started
 				## send info out to flume
-				timestamp=$(date +%s)
-				payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
-				echo $payload > data.json
-				timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
-				rm data.json 2>&1
+				#timestamp=$(date +%s)
+				#payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+				#echo $payload > data.json
+				#timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
+				#rm data.json 2>&1
 			else
+				jobStatus="Timeout"
 				failfiles=("${failfiles[@]}" $downloadFile)
 				failtimes=("${failtimes[@]}" $st2)	## this is the last time something failed
 				failcodes=("${failcodes[@]}" $res)
@@ -172,6 +201,12 @@ function doStashCpSingle {
 				echo "Command: xrdcp $xrdargs -f root://data.ci-connect.net://$downloadFile $baseDir/$localPath 2>&1"
 				failed=$((failed+1))
 			fi
+			
+			timestamp=$(date +%s)
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			echo $payload > data.json
+			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
+			rm data.json 2>&1
 		fi
 	fi
 }

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -88,6 +88,8 @@ function doStashCpSingle {
 	dl2=0
 	st3=0
 	cache=$sourcePrefix
+	xrdexit2=-1
+	xrdexit3=-1
 
 	## First attempt
 	## Check destination directory for space in bytes
@@ -97,6 +99,7 @@ function doStashCpSingle {
 	st1=$(date +%s%3N)
 	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath
 	res=$?
+	xrdexit1=$res
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
 	if [ $res -eq 0 ]; then
@@ -116,7 +119,7 @@ function doStashCpSingle {
 		timestamp=$(date +%s)
 		timestamp=$(echo $((timestamp*1000)))
 		xrdcpVersion="$(xrdcp -V 2>&1)"
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdexit1\" : \"${xrdexit1}\", \"xrdexit2\" : \"${xrdexit2}\", \"xrdexit3\" : \"${xrdexit3}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -126,6 +129,7 @@ function doStashCpSingle {
 		st2=$(date +%s%3N)
 		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath		
 		res=$?
+		xrdexit2=$res
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		dl2=$(date +%s%3N)
 		if [ $res -eq 0 ]; then 
@@ -144,7 +148,7 @@ function doStashCpSingle {
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
 			timestamp=$(echo $((timestamp*1000)))
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdexit1\" : \"${xrdexit1}\", \"xrdexit2\" : \"${xrdexit2}\", \"xrdexit3\" : \"${xrdexit3}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
@@ -162,6 +166,7 @@ function doStashCpSingle {
 			st3=$(date +%s%3N)
 			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath
 			res=$?
+			xrdexit3=$res
 			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			dl3=$(date +%s%3N)
 			dltm=$((dl3-st3))
@@ -192,7 +197,7 @@ function doStashCpSingle {
 			
 			timestamp=$(date +%s)
 			timestamp=$(echo $((timestamp*1000)))
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdexit1\" : \"${xrdexit1}\", \"xrdexit2\" : \"${xrdexit2}\", \"xrdexit3\" : \"${xrdexit3}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -90,14 +90,13 @@ function doStashCpSingle {
 	## First attempt
 	## Check destination directory for space in bytes
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
-	dirSpace=$(echo $dirSpace *1000 | /usr/bin/bc)
+	dirSpace=$(echo $((dirSpace *1000)))
 	
 	st1=$(date +%s%3N)
 	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 	res=$?
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
-	echo "download attempt 1 complete. dSz=$dSz and exit code is $?"
 	if [ $res -eq 0 ]; then
 		## pull from local cache succeeded
 		echo "attempt 1: success"

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -1,13 +1,11 @@
 #!/bin/bash 
 
 usage="$(basename $0) [-d] [-r] [-h] <source> <destination>
-
 	-d: show debugging information
 	-r: recursively copy
 	-h: show this help text
 	
 	--closest: return closest cache location
-
 	Exit status 4 indicates that at least one file did not successfully copy over.
 	Exit status 1 indicates that the WantsStashCache classad was not present in job environment."
 
@@ -86,6 +84,10 @@ function doStashCpSingle {
 	mb=$((mySz/1000000))
 	tm=$((300+mb)) ## 5 minutes + 1MBps
 	xrdcpVersion="$(xrdcp -V 2>&1)"
+	st2=0
+	dl2=0
+	st3=0
+	cache=$sourcePrefix
 
 	## First attempt
 	## Check destination directory for space in bytes
@@ -93,14 +95,12 @@ function doStashCpSingle {
 	dirSpace=$(echo $((dirSpace *1000)))
 	
 	st1=$(date +%s%3N)
-	xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath & pid=$!
-	./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid
+	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath
 	res=$?
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
 	if [ $res -eq 0 ]; then
 		## pull from local cache succeeded
-		echo "attempt 1: success"
 		if [ $dSz -eq $mySz ]; then
 			jobStatus="Success"
 			tries=1
@@ -111,12 +111,12 @@ function doStashCpSingle {
 		if [ $3 ]; then 	## update info only if I want to
 			updateInfo $st1 $downloadFile $mySz $dltm
 		fi
-		## send info out to flume
+		## send info out to ES
 		hn=$sourcePrefix
 		timestamp=$(date +%s)
-		timestamp=$(echo "$timestamp*1000" | bc)
+		timestamp=$(echo $((timestamp*1000)))
 		xrdcpVersion="$(xrdcp -V 2>&1)"
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -124,14 +124,11 @@ function doStashCpSingle {
 		## pull from local cache failed; try again
 		## Second attempt
 		st2=$(date +%s%3N)
-		xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath & pid=$!
-		./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid		
+		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath		
 		res=$?
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		dl2=$(date +%s%3N)
-		echo "download attempt 2 complete. dSz=$dSz and exit code is $?"
 		if [ $res -eq 0 ]; then 
-			echo "attempt 2: success"
 			## second attempt to pull from local cache succeeded
 			if [ $dSz -eq $mySz ]; then
 				jobStatus="Success"
@@ -143,11 +140,11 @@ function doStashCpSingle {
 			if [ $2 ]; then 	## update info only if I want to
 				updateInfo $st2 $downloadFile $mySz $dltm
 			fi
-			## send info out to flume
+			## send info out to ES
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
-			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			timestamp=$(echo $((timestamp*1000)))
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
@@ -163,8 +160,7 @@ function doStashCpSingle {
 			## Third attempt
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
-			xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath & pid=$!
-			./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid
+			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath
 			res=$?
 			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			dl3=$(date +%s%3N)
@@ -195,8 +191,8 @@ function doStashCpSingle {
 			fi
 			
 			timestamp=$(date +%s)
-			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			timestamp=$(echo $((timestamp*1000)))
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\", \"start1\" : \"${st1}\", \"end1\" : \"${dl1}\", \"start2\" : \"${st2}\", \"end2\" : \"${dl2}\", \"start3\" : \"${st3}\", \"cache\" : \"${cache}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -282,7 +282,7 @@ if [ ! -z ${_CONDOR_JOB_AD+x} ]; then
 	fi
 fi
 
-module load xrootd/4.1.1
+module load xrootd/4.2.1
 DIR=`dirname $(readlink -f $0)`
 export PATH=$PATH:$DIR
 

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -85,7 +85,6 @@ function doStashCpSingle {
 	## if someone has 'Size: ' in their file path, they have bigger problems than this not working.
 	mb=$((mySz/1000000))
 	tm=$((300+mb)) ## 5 minutes + 1MBps
-	month=$(date +%m)
 	xrdcpVersion="$(xrdcp -V 2>&1)"
 
 	## First attempt
@@ -99,6 +98,7 @@ function doStashCpSingle {
 		
 		dSz=0
 		timestamp=$(date +%s)
+		timestamp=$(echo "$timestamp*1000" | bc)
 		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
@@ -125,6 +125,7 @@ function doStashCpSingle {
 		## send info out to flume
 		hn=$sourcePrefix
 		timestamp=$(date +%s)
+		timestamp=$(echo "$timestamp*1000" | bc)
 		xrdcpVersion="$(xrdcp -V 2>&1)"
 		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
@@ -152,6 +153,7 @@ function doStashCpSingle {
 			## send info out to flume
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
+			timestamp=$(echo "$timestamp*1000" | bc)
 			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
@@ -203,6 +205,7 @@ function doStashCpSingle {
 			fi
 			
 			timestamp=$(date +%s)
+			timestamp=$(echo "$timestamp*1000" | bc)
 			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -89,9 +89,9 @@ function doStashCpSingle {
 	xrdcpVersion="$(xrdcp -V 2>&1)"
 
 	## First attempt
-	## Check destination directory for space
+	## Check destination directory for space in bytes
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
-	noSpace=false
+	dirSpace=$(echo $dirSpace *1000 | /usr/bin/bc)
 	##if not enough space, curl jobStatus and exit
 	if [ $dirSpace -lt $mySz ]; then
 		jobStatus="Not enough space"

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -99,7 +99,8 @@ function doStashCpSingle {
 		dSz=0
 		timestamp=$(date +%s)
 		timestamp=$(echo "$timestamp*1000" | bc)
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${sourcePrefix}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		tries=0
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -117,6 +118,7 @@ function doStashCpSingle {
 		echo "attempt 1: success"
 		if [ $dSz -eq $mySz ]; then
 			jobStatus="Success"
+			tries=1
 			echo "attempt 1: size matches"
 		else
 			jobStatus="No timeout but filesize does not match downloaded size"
@@ -131,7 +133,7 @@ function doStashCpSingle {
 		timestamp=$(date +%s)
 		timestamp=$(echo "$timestamp*1000" | bc)
 		xrdcpVersion="$(xrdcp -V 2>&1)"
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -149,6 +151,7 @@ function doStashCpSingle {
 			## second attempt to pull from local cache succeeded
 			if [ $dSz -eq $mySz ]; then
 				jobStatus="Success"
+				tries=2
 				echo "attempt 2: size matches"
 			else
 				jobStatus="No timeout but filesize does not match downloaded size"
@@ -162,7 +165,7 @@ function doStashCpSingle {
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
 			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
@@ -189,6 +192,7 @@ function doStashCpSingle {
 				## pull from trunk succeeded
 				if [ $dSz -eq $mySz ]; then
 					jobStatus="Trunk Success"
+					tries=3
 					echo "trunk success"
 				else
 					jobStatus="Downloaded from trunk - No timeout but filesize does not match downloaded size"
@@ -208,6 +212,7 @@ function doStashCpSingle {
 				#rm data.json 2>&1
 			else
 				echo "trunk fail"
+				tries=3
 				jobStatus="Timeout"
 				failfiles=("${failfiles[@]}" $downloadFile)
 				failtimes=("${failtimes[@]}" $st2)	## this is the last time something failed
@@ -219,7 +224,7 @@ function doStashCpSingle {
 			
 			timestamp=$(date +%s)
 			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -108,8 +108,8 @@ function doStashCpSingle {
 	
 	st1=$(date +%s%3N)
 	./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
-	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	res=$?
+	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
 	echo "download attempt 1 complete. dSz=$dSz and exit code is $?"
 	if [ $res -eq 0 ]; then
@@ -140,8 +140,8 @@ function doStashCpSingle {
 		## Second attempt
 		st2=$(date +%s%3N)
 		./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
-		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		res=$?
+		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		dl2=$(date +%s%3N)
 		echo "download attempt 2 complete. dSz=$dSz and exit code is $?"
 		if [ $res -eq 0 ]; then 
@@ -180,8 +180,8 @@ function doStashCpSingle {
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
 			./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
-			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			res=$?
+			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			dl3=$(date +%s%3N)
 			dltm=$((dl3-st3))
 			echo "tunk pull dSz=$dSz and exit code is $?"

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -180,7 +180,7 @@ function doStashCpSingle {
 				if [ $dSz -eq $mySz ]; then
 					jobStatus="Success"
 				else
-					jobStatus="No timeout but filesize does not match downloaded size"
+					jobStatus="Downloaded from trunk - No timeout but filesize does not match downloaded size"
 				fi
 				#dltm=$((dl3-st3))
 				if [ $2 ]; then

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -93,7 +93,8 @@ function doStashCpSingle {
 	dirSpace=$(echo $((dirSpace *1000)))
 	
 	st1=$(date +%s%3N)
-	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+	xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath & pid=$!
+	./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid
 	res=$?
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
@@ -123,7 +124,8 @@ function doStashCpSingle {
 		## pull from local cache failed; try again
 		## Second attempt
 		st2=$(date +%s%3N)
-		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+		xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath & pid=$!
+		./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid		
 		res=$?
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		dl2=$(date +%s%3N)
@@ -161,7 +163,8 @@ function doStashCpSingle {
 			## Third attempt
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
-			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
+			xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath & pid=$!
+			./timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz -p $pid
 			res=$?
 			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			dl3=$(date +%s%3N)

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -91,24 +91,9 @@ function doStashCpSingle {
 	## Check destination directory for space in bytes
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
 	dirSpace=$(echo $dirSpace *1000 | /usr/bin/bc)
-	##if not enough space, curl jobStatus and exit
-	#if [ $dirSpace -lt $mySz ]; then
-	#	jobStatus="Not enough space"
-	#	echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."
-	#	
-	#	dSz=0
-	#	timestamp=$(date +%s)
-	#	timestamp=$(echo "$timestamp*1000" | bc)
-	#	tries=0
-	#	payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
-	#	echo $payload > data.json
-	#	timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
-	#	rm data.json 2>&1
-	#	exit 1
-	#fi
 	
 	st1=$(date +%s%3N)
-	./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 	res=$?
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	dl1=$(date +%s%3N)
@@ -119,10 +104,8 @@ function doStashCpSingle {
 		if [ $dSz -eq $mySz ]; then
 			jobStatus="Success"
 			tries=1
-			echo "attempt 1: size matches"
 		else
 			jobStatus="No timeout but filesize does not match downloaded size"
-			echo "attempt 1: No timeout but filesize does not match downloaded size"
 		fi
 		dltm=$((dl1-st1))
 		if [ $3 ]; then 	## update info only if I want to
@@ -141,7 +124,7 @@ function doStashCpSingle {
 		## pull from local cache failed; try again
 		## Second attempt
 		st2=$(date +%s%3N)
-		./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 		res=$?
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		dl2=$(date +%s%3N)
@@ -152,10 +135,8 @@ function doStashCpSingle {
 			if [ $dSz -eq $mySz ]; then
 				jobStatus="Success"
 				tries=2
-				echo "attempt 2: size matches"
 			else
 				jobStatus="No timeout but filesize does not match downloaded size"
-				echo "attempt 2: No timeout but filesize does not match downloaded size"
 			fi
 			dltm=$((dl2-st2))
 			if [ $2 ]; then 	## update info only if I want to
@@ -171,7 +152,6 @@ function doStashCpSingle {
 			rm data.json 2>&1
 		else 	
 			## second attempt to pull from local cache failed, pulling from trunk
-			echo "pulling from trunk"
 		    	if [ $debug -eq 2 ]; then	
 				## print out debug info
 				echo "Pull of $downloadFile from $sourcePrefix failed."
@@ -182,21 +162,18 @@ function doStashCpSingle {
 			## Third attempt
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
-			./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
+			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
 			res=$?
 			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			dl3=$(date +%s%3N)
 			dltm=$((dl3-st3))
-			echo "tunk pull dSz=$dSz and exit code is $?"
 			if [ $res -eq 0 ]; then
 				## pull from trunk succeeded
 				if [ $dSz -eq $mySz ]; then
 					jobStatus="Trunk Success"
 					tries=3
-					echo "trunk success"
 				else
 					jobStatus="Downloaded from trunk - No timeout but filesize does not match downloaded size"
-					echo "Downloaded from trunk - No timeout but filesize does not match downloaded size"
 				fi
 				#dltm=$((dl3-st3))
 				if [ $2 ]; then
@@ -204,14 +181,7 @@ function doStashCpSingle {
 				fi
 				failoverfiles=("${failoverfiles[@]}" $downloadFile)
 				failovertimes=("${failovertimes[@]}" $st2) # time that the failed pull started
-				## send info out to flume
-				#timestamp=$(date +%s)
-				#payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_time\" : \"${dltm}\", \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"no_space\" : \"${noSpace}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
-				#echo $payload > data.json
-				#timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
-				#rm data.json 2>&1
 			else
-				echo "trunk fail"
 				tries=3
 				jobStatus="Timeout"
 				failfiles=("${failfiles[@]}" $downloadFile)

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -111,12 +111,16 @@ function doStashCpSingle {
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	res=$?
 	dl1=$(date +%s%3N)
+	echo "download attempt 1 complete. dSz=$dSz and exit code is $?"
 	if [ $res -eq 0 ]; then
 		## pull from local cache succeeded
+		echo "attempt 1: success"
 		if [ $dSz -eq $mySz ]; then
 			jobStatus="Success"
+			echo "attempt 1: size matches"
 		else
 			jobStatus="No timeout but filesize does not match downloaded size"
+			echo "attempt 1: No timeout but filesize does not match downloaded size"
 		fi
 		dltm=$((dl1-st1))
 		if [ $3 ]; then 	## update info only if I want to
@@ -139,12 +143,16 @@ function doStashCpSingle {
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		res=$?
 		dl2=$(date +%s%3N)
-		if [ $res -eq 0 ]; then 	
+		echo "download attempt 2 complete. dSz=$dSz and exit code is $?"
+		if [ $res -eq 0 ]; then 
+			echo "attempt 2: success"
 			## second attempt to pull from local cache succeeded
 			if [ $dSz -eq $mySz ]; then
 				jobStatus="Success"
+				echo "attempt 2: size matches"
 			else
 				jobStatus="No timeout but filesize does not match downloaded size"
+				echo "attempt 2: No timeout but filesize does not match downloaded size"
 			fi
 			dltm=$((dl2-st2))
 			if [ $2 ]; then 	## update info only if I want to
@@ -160,6 +168,7 @@ function doStashCpSingle {
 			rm data.json 2>&1
 		else 	
 			## second attempt to pull from local cache failed, pulling from trunk
+			echo "pulling from trunk"
 		    	if [ $debug -eq 2 ]; then	
 				## print out debug info
 				echo "Pull of $downloadFile from $sourcePrefix failed."
@@ -175,12 +184,15 @@ function doStashCpSingle {
 			res=$?
 			dl3=$(date +%s%3N)
 			dltm=$((dl3-st3))
+			echo "tunk pull dSz=$dSz and exit code is $?"
 			if [ $res -eq 0 ]; then
 				## pull from trunk succeeded
 				if [ $dSz -eq $mySz ]; then
-					jobStatus="Success"
+					jobStatus="Trunk Success"
+					echo "trunk success"
 				else
 					jobStatus="Downloaded from trunk - No timeout but filesize does not match downloaded size"
+					echo "Downloaded from trunk - No timeout but filesize does not match downloaded size"
 				fi
 				#dltm=$((dl3-st3))
 				if [ $2 ]; then
@@ -195,6 +207,7 @@ function doStashCpSingle {
 				#timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 				#rm data.json 2>&1
 			else
+				echo "trunk fail"
 				jobStatus="Timeout"
 				failfiles=("${failfiles[@]}" $downloadFile)
 				failtimes=("${failtimes[@]}" $st2)	## this is the last time something failed

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -99,7 +99,7 @@ function doStashCpSingle {
 		dSz=0
 		timestamp=$(date +%s)
 		timestamp=$(echo "$timestamp*1000" | bc)
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${sourcePrefix}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -107,7 +107,7 @@ function doStashCpSingle {
 	fi
 	
 	st1=$(date +%s%3N)
-	downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+	./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 	dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 	res=$?
 	dl1=$(date +%s%3N)
@@ -139,7 +139,7 @@ function doStashCpSingle {
 		## pull from local cache failed; try again
 		## Second attempt
 		st2=$(date +%s%3N)
-		downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
+		./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz $tm xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
 		dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 		res=$?
 		dl2=$(date +%s%3N)
@@ -179,7 +179,7 @@ function doStashCpSingle {
 			## Third attempt
 			hn="root://data.ci-connect.net"
 			st3=$(date +%s%3N)
-			downloading_timeout.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
+			./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $hn://$downloadFile $baseDir/$localPath 
 			dSz=$(du -b -s $baseDir/$localPath | cut -f -1)
 			res=$?
 			dl3=$(date +%s%3N)

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -92,20 +92,20 @@ function doStashCpSingle {
 	dirSpace=$(df -k $baseDir | tail -1 | awk '{print $3}')
 	dirSpace=$(echo $dirSpace *1000 | /usr/bin/bc)
 	##if not enough space, curl jobStatus and exit
-	if [ $dirSpace -lt $mySz ]; then
-		jobStatus="Not enough space"
-		echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."
-		
-		dSz=0
-		timestamp=$(date +%s)
-		timestamp=$(echo "$timestamp*1000" | bc)
-		tries=0
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
-		echo $payload > data.json
-		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
-		rm data.json 2>&1
-		exit 1
-	fi
+	#if [ $dirSpace -lt $mySz ]; then
+	#	jobStatus="Not enough space"
+	#	echo "Stashcp of $downloadFile failed - not enough space in $baseDir. $dirSpace bytes available, file is $mySz bytes."
+	#	
+	#	dSz=0
+	#	timestamp=$(date +%s)
+	#	timestamp=$(echo "$timestamp*1000" | bc)
+	#	tries=0
+	#	payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+	#	echo $payload > data.json
+	#	timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
+	#	rm data.json 2>&1
+	#	exit 1
+	#fi
 	
 	st1=$(date +%s%3N)
 	./downloading_timeout2.sh -t $seconds -d $diff -f $baseDir/$localPath -s $mySz xrdcp $xrdargs -f $sourcePrefix://$downloadFile $baseDir/$localPath 
@@ -133,7 +133,7 @@ function doStashCpSingle {
 		timestamp=$(date +%s)
 		timestamp=$(echo "$timestamp*1000" | bc)
 		xrdcpVersion="$(xrdcp -V 2>&1)"
-		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+		payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 		echo $payload > data.json
 		timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1 
 		rm data.json 2>&1
@@ -165,7 +165,7 @@ function doStashCpSingle {
 			hn=$sourcePrefix
 			timestamp=$(date +%s)
 			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1
@@ -224,7 +224,7 @@ function doStashCpSingle {
 			
 			timestamp=$(date +%s)
 			timestamp=$(echo "$timestamp*1000" | bc)
-			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
+			payload="{ \"timestamp\" : \"${timestamp}\", \"host\" : \"${hn}\",\"filename\" : \"${downloadFile}\", \"filesize\" : \"${mySz}\", \"download_size\" : \"${dSz}\", \"download_time\" : \"${dltm}\",  \"sitename\" : \"${OSG_SITE_NAME}\", \"destination_space\" : \"${dirSpace}\", \"status\" : \"${jobStatus}\", \"xrdcp_exit\" : \"${res}\", \"tries\" : \"${tries}\", \"xrdcp_version\" : \"${xrdcpVersion}\"}"
 			echo $payload > data.json
 			timeout 10 curl -XPOST uct2-int.mwt2.org:9951 -d @data.json > /dev/null 2>&1
 			rm data.json 2>&1


### PR DESCRIPTION
This is the current version of stashcp and downloading_timeout.sh I have been using locally that has fixed many of the original errors for me.

downloading_timeout.sh now kills xrdcp properly in the case of a timeout, keeps its exit code whether it is killed or aborts itself, and reports it to ES. 
stashcp has variables added to its ES index, including checkpoints of where stashcp aborted if it did, and why. It also uses a newer version of xrootd.