### PR TITLE
Fixing first slash regression

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -339,6 +339,10 @@ def main():
     else:
         cache = get_best_stashcache()
     
+    if not source.startswith('/'):
+        logging.warning("DEPRECIATED: The source path does not begin with a '/', but it is required.  This functionality will be removed in an upcoming release")
+        source = "/" + source
+    
     if not args.recursive:
         doStashCpSingle(sourceFile=source, destination=destination, cache=cache, debug=args.debug)
     else:

--- a/bin/stashcp2/tests/test_inside_docker.sh
+++ b/bin/stashcp2/tests/test_inside_docker.sh
@@ -36,6 +36,17 @@ module load xrootd
 
 cp /StashCache/bin/caches.json /StashCache/bin/stashcp2/caches.json
 
+# Try copying with no forward slash
+/StashCache/bin/stashcp --cache=$XRD_CACHE user/dweitzel/public/blast/queries/query1 ./
+
+result=`md5sum query1 | awk '{print $1;}'`
+
+if [ "$result" != "12bdb9a96cd5e8ca469b727a81593201" ]; then
+  exit 1
+fi
+
+rm query1
+
 # Perform tests
 /StashCache/bin/stashcp --cache=$XRD_CACHE -d /user/dweitzel/public/blast/queries/query1 ./
 


### PR DESCRIPTION
In the old version of stashcp, no forward `/` was required in the source path.  Add back this functionality, and a depreciation warning.