### PR TITLE
Make file size query failure not fatal

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -180,16 +180,15 @@ def doStashCpSingle(sourceFile, destination, debug=False):
     xrdcp_version = subprocess.Popen(['echo $(xrdcp -V 2>&1)'], stdout=subprocess.PIPE, shell=True).communicate()[0][:-1]
     try:
         fileSize = int(re.findall(r"Size:   \d+", xrdfs_stdout)[0].split(":   ")[1])
-    except Exception as e:
-        sys.stderr.write("Unable to find size of file\n")
+        logging.debug("Size of the file %s is %s", sourceFile, fileSize)
+        payload['filesize'] = fileSize
+    except (ValueError, IndexError) as e:
+        sys.stderr.write("Unable to find size of file from the origin\n")
         print str(xrdfs_stdout)
         sys.stderr.write(str(xrdfs_stderr))
         sys.stderr.write("\n")
-        return 1
-    logging.debug("Size of the file %s is %s", sourceFile, str(fileSize))
     
     payload['xrdcp_version'] = xrdcp_version
-    payload['filesize'] = fileSize
     
     end1=int(time.time()*1000)
     payload['end1']=end1

--- a/bin/stashcp
+++ b/bin/stashcp
@@ -221,6 +221,8 @@ def doStashCpSingle(sourceFile, destination, debug=False):
         payload['status']=status
         payload['tries']=tries
         payload['cache']=nearest_cache
+        if 'filesize' not in payload:
+            payload['filesize']=dlSz
         es_send(payload)
 
     else: #pull from origin
@@ -249,6 +251,8 @@ def doStashCpSingle(sourceFile, destination, debug=False):
         payload['start3']=start3
         payload['end3']=end3
         payload['cache']=nearest_cache
+        if 'filesize' not in payload:
+            payload['filesize']=dlSz
         es_send(payload)
         if xrd_exit == '0':
             return 0


### PR DESCRIPTION
Don't make it be an error if we fail to find the size of the file by querying the origin.