### PR TITLE
Initialize dlSz to avoid NameError when transfer fails

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -199,6 +199,8 @@ def doStashCpSingle(sourceFile, destination, debug=False):
     xrd_exit=timed_transfer(filename=sourceFile, debug=debug, destination=destination)
     
     end2=int(time.time()*1000)
+
+    dlSz=0
     if os.path.exists(destination):
         dlSz=os.stat(destination).st_size
     destSpace=1


### PR DESCRIPTION
This would happen at the `payload['download_size']=dlSz` line since `dlSz` is only set when the destination file exists.