### PR TITLE
changing default location of caches.json (SOFTWARE-3799)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='5.4.1',  # Required
+    version='5.4.2',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
@@ -160,7 +160,7 @@ setup(
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
     #
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[('', ['caches.json'])],  # Optional
+    data_files=[('share/stashcache', ['caches.json'])],  # Optional
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/stashcp.py
+++ b/stashcp.py
@@ -14,11 +14,6 @@ import random
 import shutil
 from urlparse import urlparse
 
-try:
-    from pkg_resources import resource_string
-except ImportError as e:
-    resource_string = None
-
 
 import logging
 from urlparse import urlparse
@@ -554,14 +549,9 @@ def get_best_stashcache():
         cache_files = [ caches_json_location ]
     else:
         prefix = os.environ.get("OSG_LOCATION", "/")
-        cache_files = [os.path.join(os.path.dirname(os.path.realpath(__file__)), "caches.json"),
-                       os.path.join(prefix, "etc/stashcache/caches.json"),
-                       os.path.join(prefix, "usr/share/stashcache/caches.json")]
-        if resource_string:
-            try:
-                cache_files.insert(0, resource_string(__name__, 'caches.json'))
-            except IOError as ioe:
-                logging.debug("Unable to retrieve caches.json using resource string, trying other locations")
+        cache_files = [os.path.join(prefix, "etc/stashcache/caches.json"),
+                       os.path.join(prefix, "usr/share/stashcache/caches.json"),
+                       os.path.join(prefix, "usr/local/share/stashcache/caches.json")]
 
     for cache_file in cache_files:
         if os.path.isfile(cache_file):


### PR DESCRIPTION
I got from @matyasselmeci that we don't want the config file within the package directory, instead we want it on /usr/share so I've made that the default location and removed the part of the code that looks for the file within the package directory.